### PR TITLE
[Feature] 메인페이지 테이블 칼럼 커스터마이징 기능 추가

### DIFF
--- a/src/Pages/MainPage/FilterModal.jsx
+++ b/src/Pages/MainPage/FilterModal.jsx
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+const filterArrays = [
+  { label: '팀', index: 0 },
+  { label: '역할', index: 1 },
+  { label: '출석', index: 3 },
+  { label: '결석', index: 4 },
+  { label: '휴가', index: 5 },
+  { label: '목표', index: 8 },
+];
+
+const FilterModal = ({ customData, onClickToggleCustom }) => {
+  return (
+    <FilterModalContainer>
+      {filterArrays.map((array, i) => {
+        return (
+          <CustomColumn
+            key={i}
+            isShow={customData[array.index]}
+            onClick={() => onClickToggleCustom(array.label)}
+          >
+            {array.label}
+          </CustomColumn>
+        );
+      })}
+    </FilterModalContainer>
+  );
+};
+
+export default FilterModal;
+
+const CustomColumn = styled.span`
+  background-color: ${props => (props.isShow ? 'white' : 'gray')};
+
+  min-width: 80px;
+  height: 40px;
+  margin: 5px;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  border-radius: 10px;
+  text-align: center;
+  line-height: 40px;
+  color: rgba(0, 0, 0, 0.6);
+  cursor: pointer;
+`;
+
+const FilterModalContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(216, 216, 216, 0.9);
+`;

--- a/src/Pages/MainPage/FilterModal.jsx
+++ b/src/Pages/MainPage/FilterModal.jsx
@@ -9,39 +9,33 @@ const filterArrays = [
   { label: '목표', index: 8 },
 ];
 
-const FilterModal = ({ customData, onClickToggleCustom }) => {
+const FilterModal = ({ customData, onClickToggleCustom, setIsOpen }) => {
+  const onClickClose = () => {
+    setIsOpen(isOpen => !isOpen);
+  };
   return (
     <FilterModalContainer>
-      {filterArrays.map((array, i) => {
-        return (
-          <CustomColumn
-            key={i}
-            isShow={customData[array.index]}
-            onClick={() => onClickToggleCustom(array.label)}
-          >
-            {array.label}
-          </CustomColumn>
-        );
-      })}
+      <FilterModalBody>
+        <h1>출결 테이블 칼럼 필터링</h1>
+
+        {filterArrays.map((array, i) => {
+          return (
+            <CustomColumn
+              key={i}
+              isShow={customData[array.index]}
+              onClick={() => onClickToggleCustom(array.label)}
+            >
+              {array.label}
+            </CustomColumn>
+          );
+        })}
+      </FilterModalBody>
+      <FilterModalFooter onClick={onClickClose}>닫기</FilterModalFooter>
     </FilterModalContainer>
   );
 };
 
 export default FilterModal;
-
-const CustomColumn = styled.span`
-  background-color: ${props => (props.isShow ? 'white' : 'gray')};
-
-  min-width: 80px;
-  height: 40px;
-  margin: 5px;
-  border: 1px solid rgba(0, 0, 0, 0.6);
-  border-radius: 10px;
-  text-align: center;
-  line-height: 40px;
-  color: rgba(0, 0, 0, 0.6);
-  cursor: pointer;
-`;
 
 const FilterModalContainer = styled.div`
   position: absolute;
@@ -49,5 +43,46 @@ const FilterModalContainer = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(216, 216, 216, 0.9);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(216, 216, 216, 0.5);
+`;
+
+const FilterModalBody = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  width: 400px;
+
+  justify-content: center;
+`;
+
+const FilterModalFooter = styled.div`
+  width: 100px;
+  height: 60px;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  border-radius: 10px;
+
+  font-size: 30px;
+  text-align: center;
+  line-height: 60px;
+
+  cursor: pointer;
+`;
+const CustomColumn = styled.div`
+  background-color: ${props => (props.isShow ? 'white' : 'gray')};
+  width: 100px;
+  height: 100px;
+  margin: 15px;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  border-radius: 10px;
+
+  font-size: 30px;
+  text-align: center;
+  line-height: 100px;
+
+  color: rgba(0, 0, 0, 0.6);
+  cursor: pointer;
 `;

--- a/src/Pages/MainPage/FilterModal.jsx
+++ b/src/Pages/MainPage/FilterModal.jsx
@@ -29,8 +29,8 @@ const FilterModal = ({ customData, onClickToggleCustom, setIsOpen }) => {
             </CustomColumn>
           );
         })}
+        <FilterModalFooter onClick={onClickClose}>닫기</FilterModalFooter>
       </FilterModalBody>
-      <FilterModalFooter onClick={onClickClose}>닫기</FilterModalFooter>
     </FilterModalContainer>
   );
 };
@@ -55,13 +55,18 @@ const FilterModalBody = styled.div`
   display: flex;
   flex-wrap: wrap;
   width: 400px;
-
   justify-content: center;
+
+  background: white;
+  border-radius: 20px;
+  padding: 20px;
 `;
 
 const FilterModalFooter = styled.div`
   width: 100px;
   height: 60px;
+
+  margin: 40px;
   border: 1px solid rgba(0, 0, 0, 0.6);
   border-radius: 10px;
 

--- a/src/Pages/MainPage/FilterModal.jsx
+++ b/src/Pages/MainPage/FilterModal.jsx
@@ -77,7 +77,7 @@ const FilterModalFooter = styled.div`
   cursor: pointer;
 `;
 const CustomColumn = styled.div`
-  background-color: ${props => (props.isShow ? 'white' : 'gray')};
+  background-color: ${props => (props.isShow ? 'gray' : 'white')};
   width: 100px;
   height: 100px;
   margin: 15px;

--- a/src/Pages/MainPage/MainPageTable.jsx
+++ b/src/Pages/MainPage/MainPageTable.jsx
@@ -10,8 +10,6 @@ import CheckAttend from './CheckAttend';
 import WrongDay from './WrongDay';
 import { DataGrid } from '@mui/x-data-grid';
 
-import styled from 'styled-components';
-
 const MainPageTable = ({
   date,
   rowData,

--- a/src/Pages/MainPage/MainPageTable.jsx
+++ b/src/Pages/MainPage/MainPageTable.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { mainTableColumns, validDay, isWrongAccess } from 'Utils';
+import { validDay, isWrongAccess } from 'Utils';
 import { CHECK_IN, CHECK_OUT } from 'Utils/constants';
 import AllTableService from 'API/AllTableService';
 
@@ -12,7 +12,14 @@ import { DataGrid } from '@mui/x-data-grid';
 
 import styled from 'styled-components';
 
-const MainPageTable = ({ date, rowData, selectRowData, getUsers, userId }) => {
+const MainPageTable = ({
+  date,
+  rowData,
+  selectRowData,
+  getUsers,
+  userId,
+  mainTableColumns,
+}) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const [curFocus, setCurFocus] = useState({ id: '', select: '' });
 

--- a/src/Pages/MainPage/MainPageTable.jsx
+++ b/src/Pages/MainPage/MainPageTable.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { validDay, isWrongAccess } from 'Utils';
+import { validDay, isWrongAccess, mainTableColumns } from 'Utils';
 import { CHECK_IN, CHECK_OUT } from 'Utils/constants';
 import AllTableService from 'API/AllTableService';
 
@@ -18,10 +18,11 @@ const MainPageTable = ({
   selectRowData,
   getUsers,
   userId,
-  mainTableColumns,
+  customData,
 }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const [curFocus, setCurFocus] = useState({ id: '', select: '' });
+  const tableColumns = mainTableColumns.filter((item, i) => customData[i]);
 
   const handleClickCell = (params, event) => {
     const field = params.field;
@@ -87,7 +88,7 @@ const MainPageTable = ({
         <>
           <DataGrid
             rows={selectRowData}
-            columns={mainTableColumns}
+            columns={tableColumns}
             onCellClick={handleClickCell}
             hideFooterPagination={true} // 페이지 네이션 비활성화
             hideFooterSelectedRowCount={true} // row count 숨기기

--- a/src/Pages/MainPage/MainPageTableTabs.jsx
+++ b/src/Pages/MainPage/MainPageTableTabs.jsx
@@ -1,10 +1,17 @@
-import { mainTableColumns } from 'Utils';
-
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Divider from '@mui/material/Divider';
 
 import styled from 'styled-components';
+
+const filterArrays = [
+  { label: '팀', index: 0 },
+  { label: '역할', index: 1 },
+  { label: '출석', index: 3 },
+  { label: '결석', index: 4 },
+  { label: '휴가', index: 5 },
+  { label: '목표', index: 8 },
+];
 
 const MainPageTableTabs = ({
   tab,
@@ -12,9 +19,6 @@ const MainPageTableTabs = ({
   customData,
   setCustomData,
 }) => {
-  const columns = ['팀', '역할', '출석', '결석', '휴가', '목표'];
-  const columnsCode = [0, 1, 3, 4, 5, 8];
-
   const onClickToggleCustom = dst => {
     switch (dst) {
       case '팀':
@@ -49,14 +53,14 @@ const MainPageTableTabs = ({
         <Tab label="레드 팀" />
         <Tab label="블루 팀" />
         <Divider orientation="vertical" flexItem />
-        {columns.map((column, i) => {
+        {filterArrays.map((array, i) => {
           return (
             <CustomColumn
               key={i}
-              isShow={customData[columnsCode[i]]}
-              onClick={() => onClickToggleCustom(column)}
+              isShow={customData[array.index]}
+              onClick={() => onClickToggleCustom(array.label)}
             >
-              {column}
+              {array.label}
             </CustomColumn>
           );
         })}

--- a/src/Pages/MainPage/MainPageTableTabs.jsx
+++ b/src/Pages/MainPage/MainPageTableTabs.jsx
@@ -1,6 +1,11 @@
+import { useState } from 'react';
+
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Divider from '@mui/material/Divider';
+import FilterAltIcon from '@mui/icons-material/FilterAlt';
+
+import { validDay } from 'Utils';
 
 import styled from 'styled-components';
 
@@ -13,13 +18,35 @@ const filterArrays = [
   { label: '목표', index: 8 },
 ];
 
+const FilterModal = ({ customData, onClickToggleCustom }) => {
+  return (
+    <>
+      <>
+        {filterArrays.map((array, i) => {
+          return (
+            <CustomColumn
+              key={i}
+              isShow={customData[array.index]}
+              onClick={() => onClickToggleCustom(array.label)}
+            >
+              {array.label}
+            </CustomColumn>
+          );
+        })}
+      </>
+    </>
+  );
+};
+
 const MainPageTableTabs = ({
+  date,
   tab,
   handleChangeTab,
   customData,
   setCustomData,
 }) => {
-  const onClickToggleCustom = dst => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleClickToggleCustom = dst => {
     switch (dst) {
       case '팀':
         customData[0] = !customData[0];
@@ -46,6 +73,11 @@ const MainPageTableTabs = ({
     setCustomData(newArray);
     localStorage.setItem('customData', JSON.stringify(newArray));
   };
+
+  const toggleModal = () => {
+    setIsOpen(!isOpen);
+  };
+
   return (
     <>
       <Tabs value={tab} onChange={handleChangeTab}>
@@ -53,18 +85,14 @@ const MainPageTableTabs = ({
         <Tab label="레드 팀" />
         <Tab label="블루 팀" />
         <Divider orientation="vertical" flexItem />
-        {filterArrays.map((array, i) => {
-          return (
-            <CustomColumn
-              key={i}
-              isShow={customData[array.index]}
-              onClick={() => onClickToggleCustom(array.label)}
-            >
-              {array.label}
-            </CustomColumn>
-          );
-        })}
+        {!validDay(date) && <FilterAltIcon onClick={toggleModal} />}
       </Tabs>
+      {isOpen && (
+        <FilterModal
+          customData={customData}
+          onClickToggleCustom={handleClickToggleCustom}
+        />
+      )}
     </>
   );
 };

--- a/src/Pages/MainPage/MainPageTableTabs.jsx
+++ b/src/Pages/MainPage/MainPageTableTabs.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import FilterModal from './FilterModal';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Divider from '@mui/material/Divider';
@@ -8,35 +9,6 @@ import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import { validDay } from 'Utils';
 
 import styled from 'styled-components';
-
-const filterArrays = [
-  { label: '팀', index: 0 },
-  { label: '역할', index: 1 },
-  { label: '출석', index: 3 },
-  { label: '결석', index: 4 },
-  { label: '휴가', index: 5 },
-  { label: '목표', index: 8 },
-];
-
-const FilterModal = ({ customData, onClickToggleCustom }) => {
-  return (
-    <>
-      <>
-        {filterArrays.map((array, i) => {
-          return (
-            <CustomColumn
-              key={i}
-              isShow={customData[array.index]}
-              onClick={() => onClickToggleCustom(array.label)}
-            >
-              {array.label}
-            </CustomColumn>
-          );
-        })}
-      </>
-    </>
-  );
-};
 
 const MainPageTableTabs = ({
   date,
@@ -85,7 +57,12 @@ const MainPageTableTabs = ({
         <Tab label="레드 팀" />
         <Tab label="블루 팀" />
         <Divider orientation="vertical" flexItem />
-        {!validDay(date) && <FilterAltIcon onClick={toggleModal} />}
+        {!validDay(date) && (
+          <FilterIcon>
+            필터링
+            <FilterAltIcon onClick={toggleModal} />
+          </FilterIcon>
+        )}
       </Tabs>
       {isOpen && (
         <FilterModal
@@ -99,16 +76,4 @@ const MainPageTableTabs = ({
 
 export default MainPageTableTabs;
 
-const CustomColumn = styled.span`
-  background-color: ${props => (props.isShow ? 'white' : 'gray')};
-
-  min-width: 80px;
-  height: 40px;
-  margin: 5px;
-  border: 1px solid rgba(0, 0, 0, 0.6);
-  border-radius: 10px;
-  text-align: center;
-  line-height: 40px;
-  color: rgba(0, 0, 0, 0.6);
-  cursor: pointer;
-`;
+const FilterIcon = styled.span``;

--- a/src/Pages/MainPage/MainPageTableTabs.jsx
+++ b/src/Pages/MainPage/MainPageTableTabs.jsx
@@ -4,7 +4,12 @@ import Divider from '@mui/material/Divider';
 
 import styled from 'styled-components';
 
-const MainPageTableTabs = ({ tab, handleChangeTab }) => {
+const MainPageTableTabs = ({
+  tab,
+  handleChangeTab,
+  customData,
+  setCustomData,
+}) => {
   const columns = [
     '팀',
     '역할',
@@ -15,6 +20,14 @@ const MainPageTableTabs = ({ tab, handleChangeTab }) => {
     '체크',
     '목표',
   ];
+
+  const onClickToggleCustom = dst => {
+    console.log(customData);
+    const newColumn = customData.filter(i => !i.headerName.includes(dst));
+    console.log(newColumn);
+    setCustomData(newColumn);
+    localStorage.setItem('customData', JSON.stringify(newColumn));
+  };
   return (
     <>
       <Tabs value={tab} onChange={handleChangeTab}>
@@ -24,7 +37,11 @@ const MainPageTableTabs = ({ tab, handleChangeTab }) => {
         <Divider orientation="vertical" flexItem />
         {columns.map((column, i) => {
           return (
-            <CustomColumn key={i} isShow="true">
+            <CustomColumn
+              key={i}
+              isShow="true"
+              onClick={() => onClickToggleCustom(column)}
+            >
               {column}
             </CustomColumn>
           );

--- a/src/Pages/MainPage/MainPageTableTabs.jsx
+++ b/src/Pages/MainPage/MainPageTableTabs.jsx
@@ -1,16 +1,51 @@
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import Divider from '@mui/material/Divider';
+
+import styled from 'styled-components';
 
 const MainPageTableTabs = ({ tab, handleChangeTab }) => {
+  const columns = [
+    '팀',
+    '역할',
+    '이름',
+    '출석',
+    '결석',
+    '휴가',
+    '체크',
+    '목표',
+  ];
   return (
     <>
       <Tabs value={tab} onChange={handleChangeTab}>
         <Tab label="전체 보기" />
         <Tab label="레드 팀" />
         <Tab label="블루 팀" />
+        <Divider orientation="vertical" flexItem />
+        {columns.map((column, i) => {
+          return (
+            <CustomColumn key={i} isShow="true">
+              {column}
+            </CustomColumn>
+          );
+        })}
       </Tabs>
     </>
   );
 };
 
 export default MainPageTableTabs;
+
+const CustomColumn = styled.span`
+  background-color: ${props => (props.isShow ? 'white' : 'gray')};
+
+  min-width: 80px;
+  height: 40px;
+  margin: 5px;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  border-radius: 10px;
+  text-align: center;
+  line-height: 40px;
+  color: rgba(0, 0, 0, 0.6);
+  cursor: pointer;
+`;

--- a/src/Pages/MainPage/MainPageTableTabs.jsx
+++ b/src/Pages/MainPage/MainPageTableTabs.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import FilterModal from './FilterModal';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Divider from '@mui/material/Divider';
@@ -14,40 +13,11 @@ const MainPageTableTabs = ({
   date,
   tab,
   handleChangeTab,
-  customData,
-  setCustomData,
-}) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const handleClickToggleCustom = dst => {
-    switch (dst) {
-      case '팀':
-        customData[0] = !customData[0];
-        break;
-      case '역할':
-        customData[1] = !customData[1];
-        break;
-      case '출석':
-        customData[3] = !customData[3];
-        break;
-      case '결석':
-        customData[4] = !customData[4];
-        break;
-      case '휴가':
-        customData[5] = !customData[5];
-        break;
-      case '목표':
-        customData[8] = !customData[8];
-        break;
-      default:
-    }
-    const newArray = [...customData];
-    // 분해 할당하지 않으면 얕은 복사이기에 state가 변경되지 않음
-    setCustomData(newArray);
-    localStorage.setItem('customData', JSON.stringify(newArray));
-  };
 
+  setIsOpen,
+}) => {
   const toggleModal = () => {
-    setIsOpen(!isOpen);
+    setIsOpen(isOpen => !isOpen);
   };
 
   return (
@@ -58,22 +28,21 @@ const MainPageTableTabs = ({
         <Tab label="블루 팀" />
         <Divider orientation="vertical" flexItem />
         {!validDay(date) && (
-          <FilterIcon>
-            필터링
-            <FilterAltIcon onClick={toggleModal} />
+          <FilterIcon onClick={toggleModal}>
+            <span>필터링</span>
+            <FilterAltIcon />
           </FilterIcon>
         )}
       </Tabs>
-      {isOpen && (
-        <FilterModal
-          customData={customData}
-          onClickToggleCustom={handleClickToggleCustom}
-        />
-      )}
     </>
   );
 };
 
 export default MainPageTableTabs;
 
-const FilterIcon = styled.span``;
+const FilterIcon = styled.span`
+  cursor: pointer;
+  display: flex;
+  padding: 10px;
+  color: rgba(0, 0, 0, 0.6);
+`;

--- a/src/Pages/MainPage/MainPageTableTabs.jsx
+++ b/src/Pages/MainPage/MainPageTableTabs.jsx
@@ -12,30 +12,35 @@ const MainPageTableTabs = ({
   customData,
   setCustomData,
 }) => {
-  const columns = [
-    '팀',
-    '역할',
-    '이름',
-    '출석',
-    '결석',
-    '휴가',
-    '체크',
-    '목표',
-  ];
-  // return mainTableColumns[i].headerName.includes(dst) ? !data : data;
+  const columns = ['팀', '역할', '출석', '결석', '휴가', '목표'];
+  const columnsCode = [0, 1, 3, 4, 5, 8];
 
   const onClickToggleCustom = dst => {
-    console.log(customData);
-    const newArray = customData.map((data, i) => {
-      return columns[i].includes(dst) ? !data : data;
-    });
+    switch (dst) {
+      case '팀':
+        customData[0] = !customData[0];
+        break;
+      case '역할':
+        customData[1] = !customData[1];
+        break;
+      case '출석':
+        customData[3] = !customData[3];
+        break;
+      case '결석':
+        customData[4] = !customData[4];
+        break;
+      case '휴가':
+        customData[5] = !customData[5];
+        break;
+      case '목표':
+        customData[8] = !customData[8];
+        break;
+      default:
+    }
+    const newArray = [...customData];
+    // 분해 할당하지 않으면 얕은 복사이기에 state가 변경되지 않음
     setCustomData(newArray);
     localStorage.setItem('customData', JSON.stringify(newArray));
-    console.log('배열 : ', newArray);
-    // setCustomData(newColumn);
-    // localStorage.setItem('customData', JSON.stringify(newColumn));
-    // localStorage에 mainTableColumns이 저장될 때 renderCell 부분은 json으로 변환되지 않는다. 함수이기 때문?
-    // 배열을 그대로 저장하는 게 아닌 무엇을 껐고 무엇을 켰는지를 확인해야 한다.
   };
   return (
     <>
@@ -48,7 +53,7 @@ const MainPageTableTabs = ({
           return (
             <CustomColumn
               key={i}
-              isShow={customData[i]}
+              isShow={customData[columnsCode[i]]}
               onClick={() => onClickToggleCustom(column)}
             >
               {column}

--- a/src/Pages/MainPage/MainPageTableTabs.jsx
+++ b/src/Pages/MainPage/MainPageTableTabs.jsx
@@ -1,3 +1,5 @@
+import { mainTableColumns } from 'Utils';
+
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Divider from '@mui/material/Divider';
@@ -20,13 +22,20 @@ const MainPageTableTabs = ({
     '체크',
     '목표',
   ];
+  // return mainTableColumns[i].headerName.includes(dst) ? !data : data;
 
   const onClickToggleCustom = dst => {
     console.log(customData);
-    const newColumn = customData.filter(i => !i.headerName.includes(dst));
-    console.log(newColumn);
-    setCustomData(newColumn);
-    localStorage.setItem('customData', JSON.stringify(newColumn));
+    const newArray = customData.map((data, i) => {
+      return columns[i].includes(dst) ? !data : data;
+    });
+    setCustomData(newArray);
+    localStorage.setItem('customData', JSON.stringify(newArray));
+    console.log('배열 : ', newArray);
+    // setCustomData(newColumn);
+    // localStorage.setItem('customData', JSON.stringify(newColumn));
+    // localStorage에 mainTableColumns이 저장될 때 renderCell 부분은 json으로 변환되지 않는다. 함수이기 때문?
+    // 배열을 그대로 저장하는 게 아닌 무엇을 껐고 무엇을 켰는지를 확인해야 한다.
   };
   return (
     <>
@@ -39,7 +48,7 @@ const MainPageTableTabs = ({
           return (
             <CustomColumn
               key={i}
-              isShow="true"
+              isShow={customData[i]}
               onClick={() => onClickToggleCustom(column)}
             >
               {column}

--- a/src/Pages/MainPage/index.jsx
+++ b/src/Pages/MainPage/index.jsx
@@ -14,6 +14,8 @@ import MainPageTableTabs from './MainPageTableTabs';
 
 import styled from 'styled-components';
 
+const columns = ['팀', '역할', '이름', '출석', '결석', '휴가', '체크', '목표'];
+
 const MainPage = () => {
   const [date, setDate] = useState(new Date());
   const [tab, setTab] = useState(0);
@@ -73,7 +75,11 @@ const MainPage = () => {
 
   useEffect(() => {
     const localData = JSON.parse(localStorage.getItem('customData'));
-    setCustomData(localData ? localData : mainTableColumns);
+    setCustomData(localData ? localData : new Array(8).fill(true));
+    // true, false 배열만을 보내줄까?
+    // 아니면 여기에서 소팅이 끝난 칼럼을 보내야 하나?
+    // return mainTableColumns[i].headerName.includes(dst) ? !data : data;
+    // true, false 배열은 8개지만 칼럼 배열은 9개
   }, []);
   return (
     <MainPageContainer>
@@ -96,7 +102,7 @@ const MainPage = () => {
                 selectRowData={selectRowData}
                 getUsers={getUsers}
                 userId={userId}
-                mainTableColumns={customData}
+                mainTableColumns={mainTableColumns}
               />
             </MainPageBody>
           </MainPageTableContainer>

--- a/src/Pages/MainPage/index.jsx
+++ b/src/Pages/MainPage/index.jsx
@@ -15,6 +15,7 @@ import styled from 'styled-components';
 
 const MainPage = () => {
   const [date, setDate] = useState(new Date());
+
   const [tab, setTab] = useState(0);
   const [rowData, setRowData] = useState(null);
   const [selectRowData, setSelectRowData] = useState(null);
@@ -85,6 +86,7 @@ const MainPage = () => {
           <MainPageTableContainer>
             <MainPageBody>
               <MainPageTableTabs
+                date={date}
                 tab={tab}
                 handleChangeTab={handleChangeTab}
                 customData={customData}

--- a/src/Pages/MainPage/index.jsx
+++ b/src/Pages/MainPage/index.jsx
@@ -10,6 +10,7 @@ import ShowDate from './ShowDate';
 import UserGuide from './UserGuide';
 import MainPageTable from './MainPageTable';
 import MainPageTableTabs from './MainPageTableTabs';
+import FilterModal from './FilterModal';
 
 import styled from 'styled-components';
 
@@ -20,6 +21,7 @@ const MainPage = () => {
   const [rowData, setRowData] = useState(null);
   const [selectRowData, setSelectRowData] = useState(null);
   const [customData, setCustomData] = useState(null);
+  const [isOpen, setIsOpen] = useState(false);
 
   const auth = useContext(AuthContext);
   const userId = auth.status.userId;
@@ -43,6 +45,34 @@ const MainPage = () => {
   const handleChangeTab = (event, dstTab) => {
     setTab(dstTab);
     updateSelectData(dstTab);
+  };
+
+  const handleClickToggleCustom = dst => {
+    switch (dst) {
+      case '팀':
+        customData[0] = !customData[0];
+        break;
+      case '역할':
+        customData[1] = !customData[1];
+        break;
+      case '출석':
+        customData[3] = !customData[3];
+        break;
+      case '결석':
+        customData[4] = !customData[4];
+        break;
+      case '휴가':
+        customData[5] = !customData[5];
+        break;
+      case '목표':
+        customData[8] = !customData[8];
+        break;
+      default:
+    }
+    const newArray = [...customData];
+    // 분해 할당하지 않으면 얕은 복사이기에 state가 변경되지 않음
+    setCustomData(newArray);
+    localStorage.setItem('customData', JSON.stringify(newArray));
   };
 
   const getUsers = async () => {
@@ -89,8 +119,7 @@ const MainPage = () => {
                 date={date}
                 tab={tab}
                 handleChangeTab={handleChangeTab}
-                customData={customData}
-                setCustomData={setCustomData}
+                setIsOpen={setIsOpen}
               />
               <MainPageTable
                 date={date}
@@ -104,6 +133,13 @@ const MainPage = () => {
           </MainPageTableContainer>
         </>
       )}
+      {isOpen && (
+        <FilterModal
+          customData={customData}
+          onClickToggleCustom={handleClickToggleCustom}
+          setIsOpen={setIsOpen}
+        />
+      )}
     </MainPageContainer>
   );
 };
@@ -111,7 +147,6 @@ const MainPage = () => {
 export default MainPage;
 
 const MainPageContainer = styled.div`
-  position: relative;
   box-sizing: border-box;
   padding: 50px;
 

--- a/src/Pages/MainPage/index.jsx
+++ b/src/Pages/MainPage/index.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useContext } from 'react';
 import { AuthContext } from 'App';
 
-import { mainTableColumns } from 'Utils';
 import { TEAM, TEAM_ID } from 'Utils/constants';
 import AllTableService from 'API/AllTableService';
 
@@ -13,8 +12,6 @@ import MainPageTable from './MainPageTable';
 import MainPageTableTabs from './MainPageTableTabs';
 
 import styled from 'styled-components';
-
-const columns = ['팀', '역할', '이름', '출석', '결석', '휴가', '체크', '목표'];
 
 const MainPage = () => {
   const [date, setDate] = useState(new Date());
@@ -75,11 +72,8 @@ const MainPage = () => {
 
   useEffect(() => {
     const localData = JSON.parse(localStorage.getItem('customData'));
-    setCustomData(localData ? localData : new Array(8).fill(true));
-    // true, false 배열만을 보내줄까?
-    // 아니면 여기에서 소팅이 끝난 칼럼을 보내야 하나?
-    // return mainTableColumns[i].headerName.includes(dst) ? !data : data;
-    // true, false 배열은 8개지만 칼럼 배열은 9개
+    setCustomData(localData ? localData : new Array(9).fill(true));
+    // 전체 칼럼의 true, false 만을 저장하고 필터링은 MainPageTable에서 진행한다.
   }, []);
   return (
     <MainPageContainer>
@@ -102,7 +96,7 @@ const MainPage = () => {
                 selectRowData={selectRowData}
                 getUsers={getUsers}
                 userId={userId}
-                mainTableColumns={mainTableColumns}
+                customData={customData}
               />
             </MainPageBody>
           </MainPageTableContainer>

--- a/src/Pages/MainPage/index.jsx
+++ b/src/Pages/MainPage/index.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useContext } from 'react';
-
 import { AuthContext } from 'App';
-import { validDay } from 'Utils';
+
+import { mainTableColumns } from 'Utils';
 import { TEAM, TEAM_ID } from 'Utils/constants';
 import AllTableService from 'API/AllTableService';
 
@@ -19,6 +19,7 @@ const MainPage = () => {
   const [tab, setTab] = useState(0);
   const [rowData, setRowData] = useState(null);
   const [selectRowData, setSelectRowData] = useState(null);
+  const [customData, setCustomData] = useState(null);
 
   const auth = useContext(AuthContext);
   const userId = auth.status.userId;
@@ -70,6 +71,10 @@ const MainPage = () => {
     getUsers();
   }, [date]);
 
+  useEffect(() => {
+    const localData = JSON.parse(localStorage.getItem('customData'));
+    setCustomData(localData ? localData : mainTableColumns);
+  }, []);
   return (
     <MainPageContainer>
       {selectRowData && (
@@ -79,13 +84,19 @@ const MainPage = () => {
 
           <MainPageTableContainer>
             <MainPageBody>
-              <MainPageTableTabs tab={tab} handleChangeTab={handleChangeTab} />
+              <MainPageTableTabs
+                tab={tab}
+                handleChangeTab={handleChangeTab}
+                customData={customData}
+                setCustomData={setCustomData}
+              />
               <MainPageTable
                 date={date}
                 rowData={rowData}
                 selectRowData={selectRowData}
                 getUsers={getUsers}
                 userId={userId}
+                mainTableColumns={customData}
               />
             </MainPageBody>
           </MainPageTableContainer>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 메인 페이지에서 출결 테이블(표)의 속성들을 커스텀 할 수 있게끔 한다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- 팀 변경 버튼 옆의 버튼을 누르면 커스텀할 수 있는 모달창 생성.
- 변경한 정보들은 로컬 스토리지에 저장되어 새로고침하여도 적용할 수 있음.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 테이블 전체를 로컬 스토리지에 저장하려 하였으나 js 코드만 json형식으로 변환되어서 renderCell 부분이 변환되지 않았음.
- 각 요소가 칼럼에 해당하는 일차원 배열을 통해 관리. index를 지정해 바꿈으로써 순서에 구애받지 않고 커스텀할 수 있게끔 하였음.

<br />

## :: 기타 질문 및 특이 사항

-
